### PR TITLE
Add search to moments and listings

### DIFF
--- a/src/pages/account.comp.js
+++ b/src/pages/account.comp.js
@@ -268,11 +268,11 @@ export function Account() {
 
   useEffect(()=>{
     loadFilteredMoments(moments)
-  }, [searchMoments])
+  }, [searchMoments, searchMomentsType])
 
   useEffect(()=>{
     loadFilteredListings(listings)
-  }, [searchListings])
+  }, [searchListings, searchListingsType])
 
   const handleSearchMomentChange = (e) => {
     setSearchMoments(e.target.value)

--- a/src/pages/account.comp.js
+++ b/src/pages/account.comp.js
@@ -149,6 +149,30 @@ const Muted = styled.span`
 
 const H1 = styled.h1``
 
+const Select = styled.select`
+  margin-left: 20px;
+  height: 30px;
+  font-size: 18px;
+  border-radius: 15px;
+  border-color: grey;
+  padding-left: 5px;
+`
+
+const Input = styled.input`
+  margin-left: 20px;
+  height: 30px;
+  font-size: 18px;
+  border-radius: 15px;
+  border-color: grey;
+  border-width: 1px;
+  padding-left: 5px;
+`
+
+const Span = styled.span`
+  margin-left: 20px;
+  font-size: 18px;
+`
+
 export function Account() {
   const {address} = useParams()
   const [acct, setAcct] = useState(null)
@@ -173,20 +197,24 @@ export function Account() {
     getAccount(address).then(setAcct).catch(setError)
   }, [address])
 
-  const [moments, setMoments] = useState(null)
+  const [moments, setMoments] = useState([])
+  const [filteredMoments, setFilteredMoments] = useState([])
   useEffect(() => {
     getMoments(address, momentIDs)
       .then((m) => {
         setMoments(m)
+        setFilteredMoments(m)
       })
       .catch(setError)
   }, [address, momentIDs])
 
-  const [listings, setListings] = useState(null)
+  const [listings, setListings] = useState([])
+  const [filteredListings, setFilteredListings] = useState([])
   useEffect(() => {
     getListings(address, saleMomentIDs)
       .then((l) => {
         setListings(l)
+        setFilteredListings(l)
       })
       .catch(setError)
   }, [address, saleMomentIDs])
@@ -200,6 +228,44 @@ export function Account() {
     let mIDs = topshotAccount.saleMomentIDs.slice(data.selected * 20, data.selected * 20 + 20)
     setSaleMomentIDs(mIDs)
   }
+
+  // add search
+  const [searchMomentsType, setSearchMomentsType] = useState(null)
+  const [searchListingsType, setSearchListingsType] = useState(null)
+
+  const handleSearchMomentChange = (e) => {
+    let value = e.target.value
+    if(value == ""){
+      setFilteredMoments(moments)
+      return
+    }
+    let fMoments = []
+    moments.map(moment=>{
+      const element = (searchMomentsType == "playName") ? moment.play.FullName : moment[searchMomentsType]
+      if (element.toString().toLowerCase().startsWith(value.toLowerCase())){
+        fMoments.push(moment)
+      }
+    })
+    setFilteredMoments(fMoments)
+  }
+
+  const handleSearchListingChange = (e) => {
+    let value = e.target.value
+    if(value == ""){
+      setFilteredListings(listings)
+      return
+    }
+    let fListings = []
+    listings.map(listing=>{
+      const element = (searchListingsType == "playName") ? listing.play.FullName : listing[searchListingsType]
+      if (element.toString().toLowerCase().startsWith(value.toLowerCase())){
+        fListings.push(listing)
+      }
+    })
+    setFilteredListings(fListings)
+  }
+
+  
   if (error != null)
     return (
       <Root>
@@ -239,10 +305,18 @@ export function Account() {
         <h3>
           <span>Moments</span>
           <Muted> {topshotAccount && topshotAccount.momentIDs.length}</Muted>
+          <Span>Search By:</Span>
+          <Select onChange={(e)=>{setSearchMomentsType(e.target.value)}}>
+            <option value="id">ID</option>
+            <option value="setName">Set Name</option>
+            <option value="playName">Play Name</option>
+            <option value="serialNumber">Serial Number</option>
+          </Select>
+          <Input type="text" onChange={handleSearchMomentChange}/>
         </h3>
         {/* <MomentList></MomentList> */}
 
-        {moments && !!moments.length && (
+        {filteredMoments && !!filteredMoments.length && (
           <div>
             <Table striped bordered hover size="sm">
               <thead>
@@ -254,7 +328,7 @@ export function Account() {
                 </tr>
               </thead>
               <tbody>
-                {moments
+                {filteredMoments
                   .sort((a, b) => {
                     return a.setName === b.setName ? 0 : +(a.setName > b.setName) || -1
                   })
@@ -296,8 +370,17 @@ export function Account() {
         <h3>
           <span>Listings</span>
           <Muted> {topshotAccount && topshotAccount.saleMomentIDs.length}</Muted>
+          <Span>Search By:</Span>
+          <Select onChange={(e)=>{setSearchListingsType(e.target.value)}}>
+            <option value="id">ID</option>
+            <option value="setName">Set Name</option>
+            <option value="playName">Play Name</option>
+            <option value="serialNumber">Serial Number</option>
+            <option value="price">Price</option>
+          </Select>
+          <Input type="text" onChange={handleSearchListingChange}/>
         </h3>
-        {listings && !!listings.length && (
+        {filteredListings && !!filteredListings.length && (
           <div>
             <Table striped bordered hover size="sm">
               <thead>
@@ -310,7 +393,7 @@ export function Account() {
                 </tr>
               </thead>
               <tbody>
-                {listings
+                {filteredListings
                   .sort((a, b) => {
                     return a.setName === b.setName ? 0 : +(a.setName > b.setName) || -1
                   })

--- a/src/pages/account.comp.js
+++ b/src/pages/account.comp.js
@@ -203,7 +203,7 @@ export function Account() {
     getMoments(address, momentIDs)
       .then((m) => {
         setMoments(m)
-        setFilteredMoments(m)
+        loadFilteredMoments(m)
       })
       .catch(setError)
   }, [address, momentIDs])
@@ -214,7 +214,7 @@ export function Account() {
     getListings(address, saleMomentIDs)
       .then((l) => {
         setListings(l)
-        setFilteredListings(l)
+        loadFilteredListings(l)
       })
       .catch(setError)
   }, [address, saleMomentIDs])
@@ -230,39 +230,56 @@ export function Account() {
   }
 
   // add search
-  const [searchMomentsType, setSearchMomentsType] = useState(null)
-  const [searchListingsType, setSearchListingsType] = useState(null)
+  const [searchMoments, setSearchMoments] = useState("")
+  const [searchListings, setSearchListings] = useState("")
+  const [searchMomentsType, setSearchMomentsType] = useState("id")
+  const [searchListingsType, setSearchListingsType] = useState("id")
 
-  const handleSearchMomentChange = (e) => {
-    let value = e.target.value
-    if(value == ""){
-      setFilteredMoments(moments)
+
+  const loadFilteredMoments = (m)=>{
+    if(searchMoments == ""){
+      setFilteredMoments(m)
       return
     }
     let fMoments = []
-    moments.map(moment=>{
+    m.map(moment=>{
       const element = (searchMomentsType == "playName") ? moment.play.FullName : moment[searchMomentsType]
-      if (element.toString().toLowerCase().startsWith(value.toLowerCase())){
+      if (element.toString().toLowerCase().startsWith(searchMoments.toLowerCase())){
         fMoments.push(moment)
       }
     })
     setFilteredMoments(fMoments)
   }
 
-  const handleSearchListingChange = (e) => {
-    let value = e.target.value
-    if(value == ""){
-      setFilteredListings(listings)
+  const loadFilteredListings = (l)=>{
+    if(searchListings == ""){
+      setFilteredListings(l)
       return
     }
     let fListings = []
-    listings.map(listing=>{
+    l.map(listing=>{
       const element = (searchListingsType == "playName") ? listing.play.FullName : listing[searchListingsType]
-      if (element.toString().toLowerCase().startsWith(value.toLowerCase())){
+      if (element.toString().toLowerCase().startsWith(searchListings.toLowerCase())){
         fListings.push(listing)
       }
     })
     setFilteredListings(fListings)
+  }
+
+  useEffect(()=>{
+    loadFilteredMoments(moments)
+  }, [searchMoments])
+
+  useEffect(()=>{
+    loadFilteredListings(listings)
+  }, [searchListings])
+
+  const handleSearchMomentChange = (e) => {
+    setSearchMoments(e.target.value)
+  }
+
+  const handleSearchListingChange = (e) => {
+    setSearchListings(e.target.value)
   }
 
   
@@ -306,13 +323,13 @@ export function Account() {
           <span>Moments</span>
           <Muted> {topshotAccount && topshotAccount.momentIDs.length}</Muted>
           <Span>Search By:</Span>
-          <Select onChange={(e)=>{setSearchMomentsType(e.target.value)}}>
+          <Select onChange={(e)=>{setSearchMomentsType(e.target.value)}} value={searchMomentsType}>
             <option value="id">ID</option>
             <option value="setName">Set Name</option>
             <option value="playName">Play Name</option>
             <option value="serialNumber">Serial Number</option>
           </Select>
-          <Input type="text" onChange={handleSearchMomentChange}/>
+          <Input type="text" value={searchMoments} onChange={handleSearchMomentChange}/>
         </h3>
         {/* <MomentList></MomentList> */}
 
@@ -371,14 +388,14 @@ export function Account() {
           <span>Listings</span>
           <Muted> {topshotAccount && topshotAccount.saleMomentIDs.length}</Muted>
           <Span>Search By:</Span>
-          <Select onChange={(e)=>{setSearchListingsType(e.target.value)}}>
+          <Select onChange={(e)=>{setSearchListingsType(e.target.value)}} value={searchListingsType}>
             <option value="id">ID</option>
             <option value="setName">Set Name</option>
             <option value="playName">Play Name</option>
             <option value="serialNumber">Serial Number</option>
             <option value="price">Price</option>
           </Select>
-          <Input type="text" onChange={handleSearchListingChange}/>
+          <Input type="text" value={searchListings} onChange={handleSearchListingChange}/>
         </h3>
         {filteredListings && !!filteredListings.length && (
           <div>


### PR DESCRIPTION
This PR adds an advanced search to moments and listings.
Users can search moments by `ID, Set Name, Play Name and Serial Number`.
![Screenshot 2020-11-21 at 3 45 55 PM](https://user-images.githubusercontent.com/11295174/99879973-c15b0a00-2c10-11eb-8c19-a5d8367f4d13.png)

Users can search listings by `ID, Set Name, Play Name and Serial Number, price`.

![Screenshot 2020-11-21 at 3 49 15 PM](https://user-images.githubusercontent.com/11295174/99880022-2151b080-2c11-11eb-9558-c5ae3bedc7b1.png)

Search filter is applied automatically on page change