### PR TITLE
added play category metadata to plays/set

### DIFF
--- a/src/pages/plays.comp.js
+++ b/src/pages/plays.comp.js
@@ -59,6 +59,11 @@ const columns = [
       sortable: true
   },
   {
+      key: "playCategory",
+      text: "Play Category",
+      sortable: true
+  },
+  {
       key: "teamAtMoment",
       text: "Team at Moment",
       align: "left",
@@ -151,7 +156,7 @@ export function TopshotPlays() {
 
   const data = topshotPlays.plays?.map((play) => {
     return {playID: play.playID, fullName: play.metadata.FullName,
-      playType: play.metadata.PlayType, teamAtMoment: play.metadata.TeamAtMoment}
+      playType: play.metadata.PlayType, playCategory: play.metadata.PlayCategory, teamAtMoment: play.metadata.TeamAtMoment}
   })
 
   return (

--- a/src/pages/set.comp.js
+++ b/src/pages/set.comp.js
@@ -118,6 +118,11 @@ const columns = [
       sortable: true
   },
   {
+      key: "playCategory",
+      text: "Play Category",
+      sortable: true
+  },
+  {
       key: "totalMinted",
       text: "Total Minted",
       align: "left",
@@ -215,7 +220,7 @@ export function TopshotSet() {
   const data = TopshotSet.set.editions?.map((edition) => {
     var play = getPlay(edition.playID)[0]
     return {playID: play.playID, retired: edition.retired ? <Red>retired</Red> : <Green>open</Green>, fullName: play.metadata.FullName,
-      playType: play.metadata.PlayType, totalMinted: edition.momentCount, playOrder: edition.playOrder}
+      playType: play.metadata.PlayType, playCategory: play.metadata.PlayCategory, totalMinted: edition.momentCount, playOrder: edition.playOrder}
   })
   return (
     <Root>


### PR DESCRIPTION
This is a minor PR to add Play Category to the plays and set pages.

The goal is to remove some ambiguity stemming from play type (eg. Rim types can be either Dunk or Layup) and match the play used on the NBA Top Shot site.

![Screen Shot 2021-05-10 at 9 34 58 AM](https://user-images.githubusercontent.com/6492289/117677113-c76b8580-b173-11eb-94de-fd3c165b3a3e.png)
